### PR TITLE
Escaped projectPath to support directories with spaces

### DIFF
--- a/lib/open-project-in-tower.coffee
+++ b/lib/open-project-in-tower.coffee
@@ -14,5 +14,5 @@ module.exports =
     return unless projectPaths
 
     projectPaths.forEach (projectPath) ->
-      proc.exec "open -a Tower.app #{projectPath}", (error) ->
+      proc.exec "open -a Tower.app \'#{projectPath}\'", (error) ->
         console.log "error: #{error}" unless error is null


### PR DESCRIPTION
If a directory in the project path included a space, this module would fail to work. This update fixes that.
