### PR TITLE
Improve context menu item

### DIFF
--- a/menus/open-project-in-tower.cson
+++ b/menus/open-project-in-tower.cson
@@ -1,4 +1,5 @@
-# See https://atom.io/docs/latest/creating-a-package#menus for more details
-
 'context-menu':
-  '.platform-darwin .tree-view': [{label: 'Open Project in Tower', command: 'open-project-in-tower:open'}]
+  '.tree-view .header[title],
+   [class^="status-bar"] .git-branch': [
+    label: 'Open Project in Tower', command: 'open-project-in-tower:open'
+  ]


### PR DESCRIPTION
Limit the context menu item to only root projects in the tree view.

Signed-off-by: Daniel Bayley daniel.bayley@me.com
