### PR TITLE
Improve context menu item (again)

### DIFF
--- a/menus/open-project-in-tower.cson
+++ b/menus/open-project-in-tower.cson
@@ -1,5 +1,6 @@
 'context-menu':
-  '.tree-view .header[title],
+  '.tree-view .header .icon-repo,
+   .header .tree-view-git-status,
    [class^="status-bar"] .git-branch': [
     label: 'Open Project in Tower', command: 'open-project-in-tower:open'
   ]


### PR DESCRIPTION
Limit the context menu item to only root projects in the tree view.
